### PR TITLE
This fork is obsolete and unmaintained, please mark it so

### DIFF
--- a/lib/Graph.pm
+++ b/lib/Graph.pm
@@ -22,8 +22,13 @@ $VERSION = '0.96_01';
 
 require 5.006; # Weak references are absolutely required.
 
+use version 0.77;
+
 my $can_deep_copy_Storable =
-    eval 'require Storable; require B::Deparse; $Storable::VERSION >= 2.05 && $B::Deparse::VERSION >= 0.61' && !$@;
+    eval { require Storable; 1 } &&
+    eval { require B::Deparse; 1 } &&
+    eval { version->parse($Storable::VERSION) >= version->parse("2.05") &&
+	       version->parse($B::Deparse::VERSION) >= version->parse("0.61") };
 
 sub _can_deep_copy_Storable () {
     return $can_deep_copy_Storable;


### PR DESCRIPTION
On FreeBSD 11.1, the currently available Perl5 package (`perl5-5.24.3`) has a Storable module in core with version `2.56_01`.  This makes Graph's version check unhappy; I get `Argument "2.56_01" isn't numeric in numeric ge (>=) at (eval 6) line 1 (#1)` when using the module.  This fixes that.

This commit appears to work correctly on that Perl version.  I make no claims of testing on ancient Perl versions or of being an experienced Perl developer, but I think this should work fairly far back.
